### PR TITLE
feat: review guide tab, token page, submission flow, status & reissue

### DIFF
--- a/app/api/applicants/status/route.ts
+++ b/app/api/applicants/status/route.ts
@@ -18,6 +18,26 @@ export async function POST(req: NextRequest) {
       .insert([{ applicant_id: applicantId, action: `manual-${status}`, actor: actor ?? "system", created_at: new Date().toISOString() }]);
     if (logErr) throw logErr;
 
+    // When selected, create or reuse review invite
+    if (status === "selected") {
+      // fetch applicant project's id
+      const { data: applicant } = await supabase.from("applicants").select("project_id").eq("id", applicantId).maybeSingle();
+      const projectId = (applicant as any)?.project_id;
+      if (projectId) {
+        try {
+          const base = process.env.APP_BASE_URL || process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
+          const resp = await fetch(`${base}/api/review/invite`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ projectId, applicantId, credits: 3, ttlDays: 30 }),
+          });
+          const json = await resp.json();
+          // Attach preview link into logs for auditing
+          await supabase.from("logs").insert([{ applicant_id: applicantId, action: `invite-link ${json?.link || "-"}` }]);
+        } catch {}
+      }
+    }
+
     return NextResponse.json({ ok: true });
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : "unknown";

--- a/app/api/review/generate/route.ts
+++ b/app/api/review/generate/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabase } from "@/lib/supabase/client";
+
+export const runtime = "edge";
+
+export async function POST(req: NextRequest) {
+  try {
+    const { token, kind } = await req.json();
+    if (!token || !kind) return NextResponse.json({ error: "token/kind required" }, { status: 400 });
+
+    const ip = (req.headers.get("x-forwarded-for") || "").split(",")[0] || "0.0.0.0";
+    const ua = req.headers.get("user-agent") || "unknown";
+
+    const supabase = getSupabase();
+
+    // rate limit: per IP per second (no more than 1), and per IP per minute (<=10)
+    const nowIso = new Date().toISOString();
+    const oneSecondAgo = new Date(Date.now() - 1000).toISOString();
+    const oneMinuteAgo = new Date(Date.now() - 60_000).toISOString();
+
+    const { count: secCount } = await supabase
+      .from("logs")
+      .select("id", { count: "exact", head: true })
+      .eq("action", "review-generate")
+      .eq("actor", ip)
+      .gt("created_at", oneSecondAgo);
+
+    if ((secCount ?? 0) >= 1) {
+      return NextResponse.json({ error: "rate limited (per second)" }, { status: 429 });
+    }
+
+    const { count: minCount } = await supabase
+      .from("logs")
+      .select("id", { count: "exact", head: true })
+      .eq("action", "review-generate")
+      .eq("actor", ip)
+      .gt("created_at", oneMinuteAgo);
+
+    if ((minCount ?? 0) >= 10) {
+      return NextResponse.json({ error: "rate limited (per minute)" }, { status: 429 });
+    }
+
+    await supabase
+      .from("logs")
+      .insert([{ action: "review-generate", actor: ip, meta: { token, kind, ua }, created_at: nowIso } as any]);
+
+    return NextResponse.json({ ok: true });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "unknown";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+

--- a/app/api/review/invite/reissue/route.ts
+++ b/app/api/review/invite/reissue/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabase } from "@/lib/supabase/client";
+
+export const runtime = "edge";
+
+export async function POST(req: NextRequest) {
+  try {
+    const { inviteId, extendDays = 0, addCredits = 1 } = await req.json();
+    if (!inviteId) return NextResponse.json({ error: "inviteId required" }, { status: 400 });
+    const supabase = getSupabase();
+    const { data: invite } = await supabase
+      .from("review_invites")
+      .select("id, credits, used, expires_at")
+      .eq("id", inviteId)
+      .maybeSingle();
+    if (!invite) return NextResponse.json({ error: "not found" }, { status: 404 });
+    const newCredits = (invite.credits ?? 0) + (addCredits ?? 0);
+    const newExpires = extendDays > 0 ? new Date((invite.expires_at ? new Date(invite.expires_at).getTime() : Date.now()) + extendDays * 86400000).toISOString() : invite.expires_at;
+    const { data, error } = await supabase
+      .from("review_invites")
+      .update({ credits: newCredits, expires_at: newExpires })
+      .eq("id", inviteId)
+      .select()
+      .single();
+    if (error) throw error;
+    return NextResponse.json({ ok: true, invite: data });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "unknown";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+

--- a/app/api/review/status/route.ts
+++ b/app/api/review/status/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabase } from "@/lib/supabase/client";
+
+export const runtime = "edge";
+
+export async function GET(req: NextRequest) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const projectId = searchParams.get("projectId");
+    if (!projectId) return NextResponse.json({ error: "projectId required" }, { status: 400 });
+    const supabase = getSupabase();
+
+    // invites joined with latest submission per invite (optional)
+    const { data: invites } = await supabase
+      .from("review_invites")
+      .select("id, applicant_id, credits, used, expires_at")
+      .eq("project_id", projectId);
+
+    const items: any[] = [];
+    for (const inv of invites ?? []) {
+      const { data: app } = await supabase.from("applicants").select("name").eq("id", inv.applicant_id).maybeSingle();
+      const { data: sub } = await supabase
+        .from("review_submissions")
+        .select("channel, url, checks")
+        .eq("invite_id", inv.id)
+        .order("created_at", { ascending: false })
+        .maybeSingle();
+      items.push({
+        invite_id: inv.id,
+        applicant: app?.name ?? null,
+        channel: sub?.channel ?? "-",
+        credits: inv.credits,
+        used: inv.used,
+        expires_at: inv.expires_at,
+        url: sub?.url ?? null,
+        passed: sub?.checks?.ok ?? null,
+      });
+    }
+
+    return NextResponse.json({ items });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "unknown";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+

--- a/app/api/review/submit/route.ts
+++ b/app/api/review/submit/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabase } from "@/lib/supabase/client";
+
+export const runtime = "edge";
+
+function extractText(html: string): string {
+  const noScript = html.replace(/<script[\s\S]*?<\/script>/gi, "").replace(/<style[\s\S]*?<\/style>/gi, "");
+  return noScript.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const { token, url, channel } = await req.json();
+    if (!token || !url) return NextResponse.json({ error: "token/url required" }, { status: 400 });
+
+    const supabase = getSupabase();
+    const { data: invite, error: invErr } = await supabase
+      .from("review_invites")
+      .select("id, project_id, credits, used, expires_at")
+      .eq("token", token)
+      .maybeSingle();
+    if (invErr || !invite) return NextResponse.json({ error: "invalid token" }, { status: 400 });
+
+    // load guide
+    const { data: pack } = await supabase
+      .from("review_packs")
+      .select("rules_json")
+      .eq("project_id", invite.project_id)
+      .order("created_at", { ascending: false })
+      .maybeSingle();
+    const guide: any = pack?.rules_json ?? {};
+
+    // fetch html
+    const resp = await fetch(url, { headers: { "User-Agent": "AIMAX-ReviewBot" } });
+    if (!resp.ok) return NextResponse.json({ error: "fetch failed" }, { status: 400 });
+    const html = await resp.text();
+    const text = extractText(html);
+
+    // run checks
+    const details: string[] = [];
+    const required = guide?.common?.requiredKeywords ?? [];
+    const links = guide?.common?.linkTargets ?? [];
+    const hasKw = required.every((k: string) => text.includes(k));
+    if (!hasKw) details.push("필수 키워드를 모두 포함하지 않았습니다");
+    const hasLinks = links.every((l: string) => html.includes(l));
+    if (!hasLinks) details.push("필수 링크가 누락되었습니다");
+    const minLen = channel === "blog" ? (guide?.blog?.paragraphLength?.min ?? 60) : (guide?.social?.sentenceLength?.min ?? 12);
+    const okLen = text.length > minLen * 2;
+    if (!okLen) details.push("길이가 너무 짧습니다");
+
+    const checks = { ok: details.length === 0, details };
+
+    // save checks regardless (history)
+    await supabase
+      .from("review_submissions")
+      .insert({ invite_id: invite.id, channel: channel ?? "blog", url, checks });
+
+    if (!checks.ok) {
+      return NextResponse.json({ ok: false, checks, suggest: details.join("\n") });
+    }
+
+    // decrement usage if available
+    if ((invite.used ?? 0) < (invite.credits ?? 0)) {
+      await supabase
+        .from("review_invites")
+        .update({ used: (invite.used ?? 0) + 1 })
+        .eq("id", invite.id);
+    }
+
+    return NextResponse.json({ ok: true, checks });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "unknown";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+

--- a/app/api/reviews/packs/route.ts
+++ b/app/api/reviews/packs/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabase } from "@/lib/supabase/client";
+
+export const runtime = "edge";
+
+type ReviewGuide = {
+  common: {
+    tone: "정보형" | "친근" | "전문";
+    forbiddenWords: string[];
+    requiredKeywords: string[];
+    linkTargets: string[];
+    cta: string;
+  };
+  blog: {
+    subheadingCount: number;
+    keywordInsertions: number;
+    anchorLinks: boolean;
+    paragraphLength: { min: number; max: number };
+  };
+  social: {
+    hashtags: string[];
+    sentenceLength: { min: number; max: number };
+    allowEmoji: boolean;
+  };
+};
+
+const DEFAULT_GUIDE: ReviewGuide = {
+  common: {
+    tone: "정보형",
+    forbiddenWords: [],
+    requiredKeywords: [],
+    linkTargets: [],
+    cta: "지금 바로 참여해 주세요",
+  },
+  blog: {
+    subheadingCount: 3,
+    keywordInsertions: 5,
+    anchorLinks: true,
+    paragraphLength: { min: 60, max: 140 },
+  },
+  social: {
+    hashtags: ["#체험단", "#리뷰"],
+    sentenceLength: { min: 12, max: 28 },
+    allowEmoji: true,
+  },
+};
+
+export async function GET(req: NextRequest) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const projectId = searchParams.get("projectId");
+    if (!projectId) return NextResponse.json({ error: "projectId required" }, { status: 400 });
+    const supabase = getSupabase();
+    const { data, error } = await supabase
+      .from("review_packs")
+      .select("id, rules_json")
+      .eq("project_id", projectId)
+      .order("created_at", { ascending: false })
+      .maybeSingle();
+    if (error) throw error;
+    return NextResponse.json({ guide: (data?.rules_json as ReviewGuide) ?? DEFAULT_GUIDE });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "unknown";
+    return NextResponse.json({ guide: DEFAULT_GUIDE, error: message, fallback: true });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const { projectId, guide } = (await req.json()) as { projectId?: string; guide?: ReviewGuide };
+    if (!projectId || !guide) return NextResponse.json({ error: "invalid payload" }, { status: 400 });
+    const supabase = getSupabase();
+    const { data: existing } = await supabase
+      .from("review_packs")
+      .select("id")
+      .eq("project_id", projectId)
+      .maybeSingle();
+    if (existing?.id) {
+      const { data, error } = await supabase
+        .from("review_packs")
+        .update({ rules_json: guide })
+        .eq("id", existing.id)
+        .select()
+        .single();
+      if (error) throw error;
+      return NextResponse.json({ pack: data });
+    }
+    const { data, error } = await supabase
+      .from("review_packs")
+      .insert({ project_id: projectId, rules_json: guide })
+      .select()
+      .single();
+    if (error) throw error;
+    return NextResponse.json({ pack: data });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "unknown";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+

--- a/app/automation/marketing/[projectId]/page.tsx
+++ b/app/automation/marketing/[projectId]/page.tsx
@@ -4,6 +4,7 @@ import ProjectActionsClient from "@/components/marketing/project-actions-client"
 import ProjectTabsClient from "@/components/marketing/project-tabs-client";
 import ProjectSyncClient from "@/components/marketing/project-sync-client";
 import PendingListClient from "@/components/marketing/pending-list-client";
+import ReviewStatus from "@/components/review/review-status";
 
 export default async function MarketingProjectPage({
   params,
@@ -29,6 +30,8 @@ export default async function MarketingProjectPage({
         <ProjectSyncClient projectId={projectId} />
         {/* pending list */}
         <PendingListClient projectId={projectId} />
+        {/* review status */}
+        <ReviewStatus projectId={projectId} />
       </div>
     </main>
   );

--- a/app/review/[token]/page.tsx
+++ b/app/review/[token]/page.tsx
@@ -1,3 +1,50 @@
+import { notFound } from "next/navigation";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import ReviewClient from "@/components/review/review-client";
+
+export default async function ReviewEntry({ params }: { params: Promise<{ token: string }> }) {
+  const { token } = await params;
+  const admin = supabaseAdmin();
+
+  // find invite by token
+  const { data: invite } = await admin
+    .from("review_invites")
+    .select("id, project_id, credits, used, expires_at, status")
+    .eq("token", token)
+    .maybeSingle();
+
+  if (!invite) {
+    notFound();
+  }
+
+  const expired = invite.expires_at ? new Date(invite.expires_at).getTime() < Date.now() : false;
+  if (expired || invite.status !== "active") {
+    return (
+      <main className="py-16 text-center">
+        <h1 className="text-2xl font-semibold mb-2">유효하지 않거나 만료된 초대입니다.</h1>
+      </main>
+    );
+  }
+
+  // load latest review pack for the project
+  const { data: pack } = await admin
+    .from("review_packs")
+    .select("rules_json")
+    .eq("project_id", invite.project_id)
+    .order("created_at", { ascending: false })
+    .maybeSingle();
+
+  const guide = pack?.rules_json ?? null;
+
+  return (
+    <main className="py-8">
+      <div className="max-w-[840px] mx-auto px-6">
+        <ReviewClient token={token} invite={invite} guide={guide} />
+      </div>
+    </main>
+  );
+}
+
 import { supabaseAdmin } from '@/lib/supabaseAdmin'
 
 export default async function ReviewEntry({ params }: { params: Promise<{ token: string }> }) {

--- a/components/marketing/project-tabs.tsx
+++ b/components/marketing/project-tabs.tsx
@@ -9,7 +9,7 @@ type ChannelRule = { min: number };
 type Rules = { blog: ChannelRule; instagram: ChannelRule; threads: ChannelRule } & Record<string, ChannelRule>;
 
 export function ProjectTabs({ projectId, projectName }: { projectId: string; projectName: string }) {
-  const [tab, setTab] = useState<"rules" | "templates">("rules");
+  const [tab, setTab] = useState<"rules" | "templates" | "review">("rules");
   const [rules, setRules] = useState<Rules>({ blog: { min: 300 }, instagram: { min: 1000 }, threads: { min: 500 } });
   const [template, setTemplate] = useState<string>(
     "{{name}}님, {{project}} 모집 관련 안내드립니다.\n\n참여 여부 회신 부탁드립니다."
@@ -22,6 +22,11 @@ export function ProjectTabs({ projectId, projectName }: { projectId: string; pro
         const res = await fetch(`/api/projects/rules?projectId=${projectId}`);
         const json = await res.json();
         if (json?.rules) setRules(json.rules);
+      } catch {}
+      try {
+        const r = await fetch(`/api/reviews/packs?projectId=${projectId}`);
+        const j = await r.json();
+        if (j?.guide) setGuide(j.guide);
       } catch {}
     })();
   }, [projectId]);
@@ -61,6 +66,7 @@ export function ProjectTabs({ projectId, projectName }: { projectId: string; pro
       <div className="flex gap-2 border-b border-[color:oklch(0.85_0.01_0)]">
         <button className={`px-3 py-2 text-sm ${tab === "rules" ? "border-b-2 border-[var(--accent)]" : "text-[var(--fg)]/70"}`} onClick={() => setTab("rules")}>기준</button>
         <button className={`px-3 py-2 text-sm ${tab === "templates" ? "border-b-2 border-[var(--accent)]" : "text-[var(--fg)]/70"}`} onClick={() => setTab("templates")}>메일 템플릿</button>
+        <button className={`px-3 py-2 text-sm ${tab === "review" ? "border-b-2 border-[var(--accent)]" : "text-[var(--fg)]/70"}`} onClick={() => setTab("review")}>리뷰 가이드</button>
       </div>
 
       {tab === "rules" ? (
@@ -83,7 +89,7 @@ export function ProjectTabs({ projectId, projectName }: { projectId: string; pro
             </div>
           </CardContent>
         </Card>
-      ) : (
+      ) : tab === "templates" ? (
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mt-4">
           <Card>
             <CardContent className="p-4 space-y-2">
@@ -104,7 +110,144 @@ export function ProjectTabs({ projectId, projectName }: { projectId: string; pro
             </CardContent>
           </Card>
         </div>
+      ) : (
+        <ReviewGuideSection projectId={projectId} />
       )}
+    </div>
+  );
+}
+
+
+type ReviewGuide = {
+  common: { tone: "정보형" | "친근" | "전문"; forbiddenWords: string[]; requiredKeywords: string[]; linkTargets: string[]; cta: string };
+  blog: { subheadingCount: number; keywordInsertions: number; anchorLinks: boolean; paragraphLength: { min: number; max: number } };
+  social: { hashtags: string[]; sentenceLength: { min: number; max: number }; allowEmoji: boolean };
+};
+
+function ReviewGuideSection({ projectId }: { projectId: string }) {
+  const [guide, setGuide] = useState<ReviewGuide | null>(null);
+  const [sample, setSample] = useState<string>("");
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const r = await fetch(`/api/reviews/packs?projectId=${projectId}`);
+        const j = await r.json();
+        if (j?.guide) setGuide(j.guide);
+      } catch {}
+    })();
+  }, [projectId]);
+
+  async function saveGuide() {
+    const res = await fetch("/api/reviews/packs", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ projectId, guide }),
+    });
+    if (res.ok) toast.success("리뷰 가이드가 저장되었습니다");
+    else toast.error("저장 실패");
+  }
+
+  function toArray(val: string) {
+    return val.split(",").map((s) => s.trim()).filter(Boolean);
+  }
+
+  function previewSample() {
+    if (!guide) return;
+    const tone = guide.common.tone;
+    const keywords = guide.common.requiredKeywords.join(", ");
+    const cta = guide.common.cta;
+    const hash = guide.social.hashtags.join(" ");
+    const blogHint = `소제목 ${guide.blog.subheadingCount}개, 키워드 ${guide.blog.keywordInsertions}회, 문단 ${guide.blog.paragraphLength.min}-${guide.blog.paragraphLength.max}자`;
+    const text = `톤: ${tone}\n필수 키워드: ${keywords}\nCTA: ${cta}\n블로그 가이드: ${blogHint}\n해시태그: ${hash}`;
+    setSample(text);
+  }
+
+  if (!guide) return <div className="mt-4 text-sm text-[var(--fg)]/70">불러오는 중…</div>;
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mt-4">
+      <Card>
+        <CardContent className="p-4 space-y-4">
+          <div className="space-y-2">
+            <div className="text-sm font-medium">공통</div>
+            <div className="flex items-center gap-3">
+              <span className="w-28 text-sm text-[var(--fg)]/80">톤</span>
+              <select className="border rounded px-2 py-1 text-sm" value={guide.common.tone} onChange={(e) => setGuide({ ...guide, common: { ...guide.common, tone: e.target.value as any } })}>
+                <option value="정보형">정보형</option>
+                <option value="친근">친근</option>
+                <option value="전문">전문</option>
+              </select>
+            </div>
+            <div className="flex items-center gap-3">
+              <span className="w-28 text-sm text-[var(--fg)]/80">금지어</span>
+              <Input className="flex-1" value={guide.common.forbiddenWords.join(", ")} onChange={(e) => setGuide({ ...guide, common: { ...guide.common, forbiddenWords: toArray(e.target.value) } })} />
+            </div>
+            <div className="flex items-center gap-3">
+              <span className="w-28 text-sm text-[var(--fg)]/80">필수 키워드</span>
+              <Input className="flex-1" value={guide.common.requiredKeywords.join(", ")} onChange={(e) => setGuide({ ...guide, common: { ...guide.common, requiredKeywords: toArray(e.target.value) } })} />
+            </div>
+            <div className="flex items-center gap-3">
+              <span className="w-28 text-sm text-[var(--fg)]/80">링크 타겟</span>
+              <Input className="flex-1" value={guide.common.linkTargets.join(", ")} onChange={(e) => setGuide({ ...guide, common: { ...guide.common, linkTargets: toArray(e.target.value) } })} />
+            </div>
+            <div className="flex items-center gap-3">
+              <span className="w-28 text-sm text-[var(--fg)]/80">CTA 문구</span>
+              <Input className="flex-1" value={guide.common.cta} onChange={(e) => setGuide({ ...guide, common: { ...guide.common, cta: e.target.value } })} />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <div className="text-sm font-medium">블로그</div>
+            <div className="flex items-center gap-3">
+              <span className="w-28 text-sm text-[var(--fg)]/80">소제목 개수</span>
+              <Input type="number" className="w-32" value={guide.blog.subheadingCount} onChange={(e) => setGuide({ ...guide, blog: { ...guide.blog, subheadingCount: Number(e.target.value || 0) } })} />
+            </div>
+            <div className="flex items-center gap-3">
+              <span className="w-28 text-sm text-[var(--fg)]/80">키워드 삽입</span>
+              <Input type="number" className="w-32" value={guide.blog.keywordInsertions} onChange={(e) => setGuide({ ...guide, blog: { ...guide.blog, keywordInsertions: Number(e.target.value || 0) } })} />
+            </div>
+            <div className="flex items-center gap-3">
+              <span className="w-28 text-sm text-[var(--fg)]/80">앵커 링크</span>
+              <input type="checkbox" checked={guide.blog.anchorLinks} onChange={(e) => setGuide({ ...guide, blog: { ...guide.blog, anchorLinks: e.target.checked } })} />
+            </div>
+            <div className="flex items-center gap-3">
+              <span className="w-28 text-sm text-[var(--fg)]/80">문단 길이</span>
+              <Input type="number" className="w-24" value={guide.blog.paragraphLength.min} onChange={(e) => setGuide({ ...guide, blog: { ...guide.blog, paragraphLength: { ...guide.blog.paragraphLength, min: Number(e.target.value || 0) } } })} />
+              <span className="text-sm">-</span>
+              <Input type="number" className="w-24" value={guide.blog.paragraphLength.max} onChange={(e) => setGuide({ ...guide, blog: { ...guide.blog, paragraphLength: { ...guide.blog.paragraphLength, max: Number(e.target.value || 0) } } })} />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <div className="text-sm font-medium">스레드/인스타</div>
+            <div className="flex items-center gap-3">
+              <span className="w-28 text-sm text-[var(--fg)]/80">해시태그</span>
+              <Input className="flex-1" value={guide.social.hashtags.join(", ")} onChange={(e) => setGuide({ ...guide, social: { ...guide.social, hashtags: toArray(e.target.value) } })} />
+            </div>
+            <div className="flex items-center gap-3">
+              <span className="w-28 text-sm text-[var(--fg)]/80">문장 길이</span>
+              <Input type="number" className="w-24" value={guide.social.sentenceLength.min} onChange={(e) => setGuide({ ...guide, social: { ...guide.social, sentenceLength: { ...guide.social.sentenceLength, min: Number(e.target.value || 0) } } })} />
+              <span className="text-sm">-</span>
+              <Input type="number" className="w-24" value={guide.social.sentenceLength.max} onChange={(e) => setGuide({ ...guide, social: { ...guide.social, sentenceLength: { ...guide.social.sentenceLength, max: Number(e.target.value || 0) } } })} />
+            </div>
+            <div className="flex items-center gap-3">
+              <span className="w-28 text-sm text-[var(--fg)]/80">이모지</span>
+              <input type="checkbox" checked={guide.social.allowEmoji} onChange={(e) => setGuide({ ...guide, social: { ...guide.social, allowEmoji: e.target.checked } })} />
+            </div>
+          </div>
+
+          <div className="flex justify-end gap-2">
+            <Button variant="secondary" onClick={previewSample}>미리보기</Button>
+            <Button className="bg-[var(--accent)] text-[var(--bg)]" onClick={saveGuide}>저장</Button>
+          </div>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardContent className="p-4">
+          <div className="text-sm whitespace-pre-wrap min-h-40">{sample}</div>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/components/marketing/project-tabs.tsx
+++ b/components/marketing/project-tabs.tsx
@@ -12,9 +12,17 @@ export function ProjectTabs({ projectId, projectName }: { projectId: string; pro
   const [tab, setTab] = useState<"rules" | "templates" | "review">("rules");
   const [rules, setRules] = useState<Rules>({ blog: { min: 300 }, instagram: { min: 1000 }, threads: { min: 500 } });
   const [template, setTemplate] = useState<string>(
-    "{{name}}님, {{project}} 모집 관련 안내드립니다.\n\n참여 여부 회신 부탁드립니다."
+    "{{name}}님, {{project}} 모집 관련 안내드립니다.\n\n아래 링크에서 리뷰 도우미로 가이드를 확인해 주세요:\n{{review_link}}\n\n참여 여부 회신 부탁드립니다."
   );
-  const preview = useMemo(() => template.replaceAll("{{name}}", "홍길동").replaceAll("{{project}}", projectName), [template, projectName]);
+  const preview = useMemo(() => {
+    const dummyToken = "testtoken123";
+    const base = typeof window !== "undefined" ? window.location.origin : "https://example.com";
+    const link = `${base}/review/${dummyToken}`;
+    return template
+      .replaceAll("{{name}}", "홍길동")
+      .replaceAll("{{project}}", projectName)
+      .replaceAll("{{review_link}}", link);
+  }, [template, projectName]);
 
   useEffect(() => {
     (async () => {

--- a/components/review/review-client.tsx
+++ b/components/review/review-client.tsx
@@ -1,0 +1,114 @@
+"use client";
+import { useMemo, useState } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { toast } from "@/components/ui/toast";
+
+type Invite = { id: string; project_id: string; credits: number; used: number; expires_at: string };
+type Guide = any;
+
+export default function ReviewClient({ token, invite, guide }: { token: string; invite: Invite; guide: Guide }) {
+  const [channel, setChannel] = useState<"blog" | "instagram" | "threads">("blog");
+  const [outline, setOutline] = useState<string>("");
+  const [draft, setDraft] = useState<string>("");
+  const [checks, setChecks] = useState<{ ok: boolean; details: string[] }>({ ok: false, details: [] });
+  const remaining = Math.max(0, (invite.credits ?? 0) - (invite.used ?? 0));
+
+  function generateOutline() {
+    const tone = guide?.common?.tone ?? "정보형";
+    const kw = (guide?.common?.requiredKeywords ?? []).slice(0, 5).join(", ");
+    const heads = guide?.blog?.subheadingCount ?? 3;
+    const outlineText = `톤: ${tone}\n키워드: ${kw}\n소제목 ${heads}개 권장\n- 서론\n- 본문(소제목 x${heads})\n- 결론(CTA 포함)`;
+    setOutline(outlineText);
+  }
+
+  function generateDraft() {
+    if (remaining <= 0) {
+      toast.error("잔여 횟수가 없습니다");
+      return;
+    }
+    const blogHint = guide?.blog ? `문단 ${guide.blog.paragraphLength?.min ?? 60}-${guide.blog.paragraphLength?.max ?? 140}자` : "";
+    const hash = guide?.social?.hashtags?.join(" ") ?? "";
+    const body = `채널: ${channel}\n\n[서론]\n제품/캠페인 소개\n\n[본문]\n특징 정리 + 키워드 반영\n\n[결론]\n${guide?.common?.cta ?? "지금 참여해 주세요"}\n\n${hash}\n${blogHint}`;
+    setDraft(body);
+  }
+
+  function runChecks() {
+    const details: string[] = [];
+    const required = guide?.common?.requiredKeywords ?? [];
+    const links = guide?.common?.linkTargets ?? [];
+    const hasKw = required.every((k: string) => draft.includes(k));
+    if (!hasKw) details.push("필수 키워드를 모두 포함하지 않았습니다");
+    const hasLinks = links.every((l: string) => draft.includes(l));
+    if (!hasLinks) details.push("필수 링크가 누락되었습니다");
+    const minLen = channel === "blog" ? (guide?.blog?.paragraphLength?.min ?? 60) : (guide?.social?.sentenceLength?.min ?? 12);
+    const okLen = draft.length > minLen * 2; // 매우 단순 체크
+    if (!okLen) details.push("길이가 너무 짧습니다");
+    setChecks({ ok: details.length === 0, details });
+  }
+
+  async function copyDraft() {
+    try {
+      await navigator.clipboard.writeText(draft);
+      toast.success("복사되었습니다");
+    } catch {
+      toast.error("복사 실패");
+    }
+  }
+
+  const disabled = remaining <= 0;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="text-sm text-[var(--fg)]/80">잔여 횟수: <b>{remaining}</b> / 만료일: {new Date(invite.expires_at).toLocaleString()}</div>
+        <div className="flex items-center gap-2 text-sm">
+          {(["blog", "instagram", "threads"] as const).map((c) => (
+            <button key={c} onClick={() => setChannel(c)} className={`px-2 py-1 rounded ${channel === c ? "border border-[var(--accent)]" : "border border-transparent text-[var(--fg)]/70"}`}>{c}</button>
+          ))}
+        </div>
+      </div>
+
+      <Card>
+        <CardContent className="p-4 space-y-3">
+          <div className="flex items-center justify-between">
+            <div className="text-sm font-medium">아웃라인 제안</div>
+            <Button variant="secondary" onClick={generateOutline}>아웃라인 생성</Button>
+          </div>
+          <textarea className="w-full h-40 rounded-md border p-2 text-sm" value={outline} onChange={(e) => setOutline(e.target.value)} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="p-4 space-y-3">
+          <div className="flex items-center justify-between">
+            <div className="text-sm font-medium">초안 생성</div>
+            <Button className="bg-[var(--accent)] text-[var(--bg)]" onClick={generateDraft} disabled={disabled}>초안 생성</Button>
+          </div>
+          <textarea className="w-full h-56 rounded-md border p-2 text-sm" value={draft} onChange={(e) => setDraft(e.target.value)} />
+          <div className="text-right text-xs text-[var(--fg)]/60">초안 생성 버튼 클릭 시 1회 차감(사용 구현은 후속 작업)</div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="p-4 space-y-3">
+          <div className="flex items-center justify-between">
+            <div className="text-sm font-medium">체크리스트</div>
+            <Button variant="secondary" onClick={runChecks}>자동 검사</Button>
+          </div>
+          {checks.details.length > 0 && (
+            <ul className="list-disc pl-6 text-sm text-[var(--err)]">
+              {checks.details.map((d, i) => (<li key={i}>{d}</li>))}
+            </ul>
+          )}
+          <div className="flex justify-end">
+            <Button onClick={copyDraft} disabled={!checks.ok}>복사하기</Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+

--- a/components/review/review-client.tsx
+++ b/components/review/review-client.tsx
@@ -13,6 +13,7 @@ export default function ReviewClient({ token, invite, guide }: { token: string; 
   const [outline, setOutline] = useState<string>("");
   const [draft, setDraft] = useState<string>("");
   const [checks, setChecks] = useState<{ ok: boolean; details: string[] }>({ ok: false, details: [] });
+  const [submitUrl, setSubmitUrl] = useState<string>("");
   const remaining = Math.max(0, (invite.credits ?? 0) - (invite.used ?? 0));
 
   function generateOutline() {
@@ -58,6 +59,24 @@ export default function ReviewClient({ token, invite, guide }: { token: string; 
   }
 
   const disabled = remaining <= 0;
+
+  async function submitPost() {
+    try {
+      const res = await fetch("/api/review/submit", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token, url: submitUrl, channel }),
+      });
+      const json = await res.json();
+      if (!res.ok || json?.ok === false) {
+        toast.error(json?.suggest || "검증 실패");
+        return;
+      }
+      toast.success("제출되었습니다");
+    } catch {
+      toast.error("제출 실패");
+    }
+  }
 
   return (
     <div className="space-y-4">
@@ -107,8 +126,22 @@ export default function ReviewClient({ token, invite, guide }: { token: string; 
           </div>
         </CardContent>
       </Card>
+
+      <Card>
+        <CardContent className="p-4 space-y-3">
+          <div className="flex items-center justify-between">
+            <div className="text-sm font-medium">게시글 업로드</div>
+            <div className="flex items-center gap-2">
+              <Input className="w-80" placeholder="게시글 URL" value={submitUrl} onChange={(e) => setSubmitUrl(e.target.value)} />
+              <Button className="bg-[var(--ok)] text-white" onClick={submitPost} disabled={!submitUrl}>업로드 완료</Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
     </div>
   );
 }
+
+// within component scope
 
 

--- a/components/review/review-status.tsx
+++ b/components/review/review-status.tsx
@@ -1,0 +1,88 @@
+"use client";
+import { useEffect, useState } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/toast";
+
+type Row = {
+  invite_id: string;
+  applicant: string | null;
+  channel: string;
+  credits: number;
+  used: number;
+  expires_at: string | null;
+  url: string | null;
+  passed: boolean | null;
+};
+
+export default function ReviewStatus({ projectId }: { projectId: string }) {
+  const [rows, setRows] = useState<Row[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  async function load() {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/review/status?projectId=${projectId}`);
+      const json = await res.json();
+      setRows(json.items ?? []);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [projectId]);
+
+  async function reissue(inviteId: string) {
+    try {
+      const res = await fetch("/api/review/invite/reissue", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ inviteId, addCredits: 1 }),
+      });
+      if (!res.ok) throw new Error();
+      toast.success("재요청 처리되었습니다");
+      load();
+    } catch {
+      toast.error("재요청 실패");
+    }
+  }
+
+  return (
+    <Card className="mt-6">
+      <CardContent className="p-4">
+        <div className="text-sm font-medium mb-2">리뷰 현황</div>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-[var(--fg)]/60">
+                <th className="py-2 pr-4">신청자</th>
+                <th className="py-2 pr-4">채널</th>
+                <th className="py-2 pr-4">잔여/만료</th>
+                <th className="py-2 pr-4">제출 URL</th>
+                <th className="py-2 pr-4">검증</th>
+                <th className="py-2 pr-4">액션</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => (
+                <tr key={`${r.invite_id}-${r.channel}`} className="border-t">
+                  <td className="py-2 pr-4">{r.applicant || "-"}</td>
+                  <td className="py-2 pr-4">{r.channel}</td>
+                  <td className="py-2 pr-4">{Math.max(0, (r.credits ?? 0) - (r.used ?? 0))} / {r.expires_at ? new Date(r.expires_at).toLocaleDateString() : "-"}</td>
+                  <td className="py-2 pr-4 truncate max-w-[320px]"><a className="underline" href={r.url ?? "#"} target="_blank" rel="noreferrer">{r.url ?? "-"}</a></td>
+                  <td className="py-2 pr-4">{r.passed ? "통과" : r.passed === false ? "미통과" : "-"}</td>
+                  <td className="py-2 pr-4"><Button variant="secondary" onClick={() => reissue(r.invite_id)}>재요청</Button></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+

--- a/docs/sql/review_schema.sql
+++ b/docs/sql/review_schema.sql
@@ -1,0 +1,157 @@
+-- review schema: tables + RLS policies
+-- Run this in Supabase SQL editor on your project
+
+begin;
+
+-- 1) Tables
+
+create table if not exists public.review_packs (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null references public.projects(id) on delete cascade,
+  rules_json jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.review_invites (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null references public.projects(id) on delete cascade,
+  applicant_id uuid not null,
+  token text unique not null,
+  credits int not null default 3,
+  expires_at timestamptz not null,
+  used int not null default 0,
+  status text not null default 'active',
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.review_drafts (
+  id uuid primary key default gen_random_uuid(),
+  invite_id uuid not null references public.review_invites(id) on delete cascade,
+  channel text not null,
+  outline jsonb,
+  draft text,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.review_submissions (
+  id uuid primary key default gen_random_uuid(),
+  invite_id uuid not null references public.review_invites(id) on delete cascade,
+  channel text not null,
+  url text,
+  checks jsonb,
+  created_at timestamptz not null default now()
+);
+
+-- 2) RLS
+
+alter table public.review_packs enable row level security;
+alter table public.review_invites enable row level security;
+alter table public.review_drafts enable row level security;
+alter table public.review_submissions enable row level security;
+
+-- Helper ownership predicate: projects.user_id = auth.uid()
+-- review_packs owner
+drop policy if exists rp_owner_select on public.review_packs;
+create policy rp_owner_select on public.review_packs
+  for select using (
+    exists (
+      select 1 from public.projects p
+      where p.id = review_packs.project_id and p.user_id = auth.uid()
+    )
+  );
+
+drop policy if exists rp_owner_ins on public.review_packs;
+create policy rp_owner_ins on public.review_packs
+  for insert with check (
+    exists (
+      select 1 from public.projects p
+      where p.id = review_packs.project_id and p.user_id = auth.uid()
+    )
+  );
+
+drop policy if exists rp_owner_upd on public.review_packs;
+create policy rp_owner_upd on public.review_packs
+  for update using (
+    exists (
+      select 1 from public.projects p
+      where p.id = review_packs.project_id and p.user_id = auth.uid()
+    )
+  );
+
+drop policy if exists rp_owner_del on public.review_packs;
+create policy rp_owner_del on public.review_packs
+  for delete using (
+    exists (
+      select 1 from public.projects p
+      where p.id = review_packs.project_id and p.user_id = auth.uid()
+    )
+  );
+
+-- review_invites owner
+drop policy if exists ri_owner_all on public.review_invites;
+create policy ri_owner_all on public.review_invites
+  for all using (
+    exists (
+      select 1 from public.projects p
+      where p.id = review_invites.project_id and p.user_id = auth.uid()
+    )
+  ) with check (
+    exists (
+      select 1 from public.projects p
+      where p.id = review_invites.project_id and p.user_id = auth.uid()
+    )
+  );
+
+-- Token-based read for invites (for anonymous access to a single row)
+-- This uses a custom JWT claim "inv_token"; the row is visible only if it matches
+-- If you don't inject a custom claim, server-side service-role queries already bypass RLS
+drop policy if exists ri_select_by_token on public.review_invites;
+create policy ri_select_by_token on public.review_invites
+  for select using (
+    -- allow when JWT contains inv_token and it matches the row token
+    (current_setting('request.jwt.claims', true)::jsonb ? 'inv_token')
+    and token = (current_setting('request.jwt.claims', true)::jsonb ->> 'inv_token')
+  );
+
+-- review_drafts owner via invite->project
+drop policy if exists rd_owner_all on public.review_drafts;
+create policy rd_owner_all on public.review_drafts
+  for all using (
+    exists (
+      select 1 from public.projects p
+      join public.review_invites ri on ri.project_id = p.id
+      where review_drafts.invite_id = ri.id and p.user_id = auth.uid()
+    )
+  ) with check (
+    exists (
+      select 1 from public.projects p
+      join public.review_invites ri on ri.project_id = p.id
+      where review_drafts.invite_id = ri.id and p.user_id = auth.uid()
+    )
+  );
+
+-- review_submissions owner via invite->project
+drop policy if exists rs_owner_all on public.review_submissions;
+create policy rs_owner_all on public.review_submissions
+  for all using (
+    exists (
+      select 1 from public.projects p
+      join public.review_invites ri on ri.project_id = p.id
+      where review_submissions.invite_id = ri.id and p.user_id = auth.uid()
+    )
+  ) with check (
+    exists (
+      select 1 from public.projects p
+      join public.review_invites ri on ri.project_id = p.id
+      where review_submissions.invite_id = ri.id and p.user_id = auth.uid()
+    )
+  );
+
+commit;
+
+-- Notes:
+-- 1) The "ri_select_by_token" policy requires injecting a custom JWT claim { inv_token: "..." }
+--    for anonymous clients. Server-side calls with service role bypass RLS, so not required there.
+-- 2) All owner policies hinge on projects.user_id = auth.uid(). Ensure RLS is enabled on projects too.
+
+


### PR DESCRIPTION
- Add '리뷰 가이드' 탭 with channel-based form and preview\n- /review/[token] page (server fetch invite + pack) and interactive client (outline/draft/checks)\n- Submit API: fetch URL, validate rules, record review_submissions, decrement usage\n- Review status section + reissue API (credits += 1 / optional extend)\n- Rate limit endpoint for generation (per IP 1/sec, 10/min) and logging\n\nRequires: review_* tables + RLS from docs/sql/review_schema.sql