### PR TITLE
fix: package.json JSON syntax and scripts placement

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "seed:applicants": "node scripts/seed_applicants.mjs",
+    "fix:rules": "node scripts/fix_default_rules.mjs"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.14",
@@ -35,7 +37,5 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "tailwindcss": "^4",
     "typescript": "^5"
-    "seed:applicants": "node scripts/seed_applicants.mjs",
-    "fix:rules": "node scripts/fix_default_rules.mjs"
   }
 }


### PR DESCRIPTION
Fix JSON syntax error in package.json caused by scripts under devDependencies.\n- Move scripts to top-level scripts field\n- Ensure trailing commas/quotes valid\n\nThis fixes Vercel build failure: Can't parse package.json.